### PR TITLE
Setup Project Zomboid Mod Skeleton (Lua)

### DIFF
--- a/mod/media/lua/server/PZStats_Events.lua
+++ b/mod/media/lua/server/PZStats_Events.lua
@@ -1,0 +1,29 @@
+-- PZStats_Events.lua
+-- Skeleton for tracking player deaths and zombie kills
+
+local function OnZombieDead(zombie)
+    local killer = zombie:getAttacker()
+    if killer and killer:getObjectName() == "IsoPlayer" then
+        local username = "Unknown"
+        if killer.getUsername then
+            username = killer:getUsername()
+        end
+        -- Log format for log-forwarder: [PZSTATS] JSON
+        print("[PZSTATS] " .. '{"event": "zombie_kill", "username": "' .. username .. '"}')
+    end
+end
+
+local function OnPlayerDeath(player)
+    local username = "Unknown"
+    if player.getUsername then
+        username = player:getUsername()
+    end
+    -- Log format for log-forwarder: [PZSTATS] JSON
+    print("[PZSTATS] " .. '{"event": "player_death", "username": "' .. username .. '"}')
+end
+
+-- Register events
+Events.OnZombieDead.Add(OnZombieDead)
+Events.OnPlayerDeath.Add(OnPlayerDeath)
+
+print("PZStats: Mod loaded successfully.")

--- a/mod/mod.info
+++ b/mod/mod.info
@@ -1,0 +1,3 @@
+name=PZ Stats
+id=pz_stats
+description=Project Zomboid Statistics Tracker


### PR DESCRIPTION
Initializes the Project Zomboid mod skeleton with the required directory structure, metadata, and event tracking for zombie kills and player death. The mod follows the 'Log Forwarder' pattern by printing JSON events to the console.

Fixes #5

---
*PR created automatically by Jules for task [2686064702886778530](https://jules.google.com/task/2686064702886778530) started by @FelBell*