### PR TITLE
Add pgAdmin Service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ POSTGRES_DB=pz_stats
 
 # API Key for the backend
 API_KEY=my_secret_api_key
+
+# pgAdmin Credentials
+PGADMIN_EMAIL=admin@pzstats.com
+PGADMIN_PASSWORD=admin_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,28 @@ services:
       - "traefik.http.routers.frontend.tls.certresolver=letsencrypt"
       - "traefik.http.services.frontend.loadbalancer.server.port=80"
 
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL?Variable not set}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD?Variable not set}
+      SCRIPT_NAME: /pgadmin
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+      - ./pgadmin/servers.json:/pgadmin4/servers.json
+    depends_on:
+      - db
+    networks:
+      - pz_net
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.pgadmin.rule=Host(`${DOMAIN?Variable not set}`) && PathPrefix(`/pgadmin`)"
+      - "traefik.http.routers.pgadmin.priority=2"
+      - "traefik.http.routers.pgadmin.entrypoints=websecure"
+      - "traefik.http.routers.pgadmin.tls.certresolver=letsencrypt"
+      - "traefik.http.services.pgadmin.loadbalancer.server.port=80"
+
   traefik:
     image: traefik:v2.5
     command:
@@ -71,6 +93,7 @@ services:
 
 volumes:
   postgres_data:
+  pgadmin_data:
 
 networks:
   pz_net:

--- a/pgadmin/servers.json
+++ b/pgadmin/servers.json
@@ -1,0 +1,13 @@
+{
+    "Servers": {
+        "1": {
+            "Name": "PZ Stats DB",
+            "Group": "Servers",
+            "Port": 5432,
+            "Username": "pz_user",
+            "Host": "db",
+            "MaintenanceDB": "pz_stats",
+            "SSLMode": "prefer"
+        }
+    }
+}


### PR DESCRIPTION
This change adds a pgAdmin service to the docker-compose.yml file, allowing users to manage the PostgreSQL database via a web interface. The service is configured to be accessible at the `/pgadmin` subpath of the main domain, protected by SSL via Traefik. It also includes a pre-configured server connection to the `db` service using a `servers.json` file.

Fixes #26

---
*PR created automatically by Jules for task [11816240762508749943](https://jules.google.com/task/11816240762508749943) started by @FelBell*